### PR TITLE
docs: remove revised timestamps

### DIFF
--- a/docs-src/themes/docdock/layouts/partials/original/head.html
+++ b/docs-src/themes/docdock/layouts/partials/original/head.html
@@ -1,6 +1,5 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
-<meta name="revised" content="{{ now.Format "2006-01-02T15:04:05 MST" }}">
 <title>{{ .Title }} :: {{ .Site.Title }}</title>
 <link rel="shortcut icon" href="{{"images/favicon.ico" | relURL}}" type="image/x-icon" />
 <link href="{{"css/nucleus.css" | relURL}}" rel="stylesheet">

--- a/docs/404.html
+++ b/docs/404.html
@@ -5,7 +5,6 @@
     
       <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
-<meta name="revised" content="2019-03-26T21:27:36 IST">
 <title>404 Page not found :: Cubic SDK -- Cobalt</title>
 <link rel="shortcut icon" href="/sdk-cubic/images/favicon.ico" type="image/x-icon" />
 <link href="/sdk-cubic/css/nucleus.css" rel="stylesheet">

--- a/docs/_header/index.html
+++ b/docs/_header/index.html
@@ -5,7 +5,6 @@
     
       <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
-<meta name="revised" content="2019-03-26T21:27:36 IST">
 <title> :: Cubic SDK -- Cobalt</title>
 <link rel="shortcut icon" href="/sdk-cubic/images/favicon.ico" type="image/x-icon" />
 <link href="/sdk-cubic/css/nucleus.css" rel="stylesheet">

--- a/docs/categories/index.html
+++ b/docs/categories/index.html
@@ -5,7 +5,6 @@
     
       <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
-<meta name="revised" content="2019-03-26T21:27:36 IST">
 <title>Categories :: Cubic SDK -- Cobalt</title>
 <link rel="shortcut icon" href="/sdk-cubic/images/favicon.ico" type="image/x-icon" />
 <link href="/sdk-cubic/css/nucleus.css" rel="stylesheet">

--- a/docs/getting-started/connecting/index.html
+++ b/docs/getting-started/connecting/index.html
@@ -5,7 +5,6 @@
     
       <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
-<meta name="revised" content="2019-03-26T21:27:36 IST">
 <title>Setup Connection :: Cubic SDK -- Cobalt</title>
 <link rel="shortcut icon" href="/sdk-cubic/images/favicon.ico" type="image/x-icon" />
 <link href="/sdk-cubic/css/nucleus.css" rel="stylesheet">

--- a/docs/getting-started/index.html
+++ b/docs/getting-started/index.html
@@ -5,7 +5,6 @@
     
       <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
-<meta name="revised" content="2019-03-26T21:27:36 IST">
 <title>Getting started :: Cubic SDK -- Cobalt</title>
 <link rel="shortcut icon" href="/sdk-cubic/images/favicon.ico" type="image/x-icon" />
 <link href="/sdk-cubic/css/nucleus.css" rel="stylesheet">

--- a/docs/getting-started/installation/index.html
+++ b/docs/getting-started/installation/index.html
@@ -5,7 +5,6 @@
     
       <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
-<meta name="revised" content="2019-03-26T21:27:36 IST">
 <title>Installation :: Cubic SDK -- Cobalt</title>
 <link rel="shortcut icon" href="/sdk-cubic/images/favicon.ico" type="image/x-icon" />
 <link href="/sdk-cubic/css/nucleus.css" rel="stylesheet">

--- a/docs/getting-started/recognize/index.html
+++ b/docs/getting-started/recognize/index.html
@@ -5,7 +5,6 @@
     
       <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
-<meta name="revised" content="2019-03-26T21:27:36 IST">
 <title>Synchronous Recognition :: Cubic SDK -- Cobalt</title>
 <link rel="shortcut icon" href="/sdk-cubic/images/favicon.ico" type="image/x-icon" />
 <link href="/sdk-cubic/css/nucleus.css" rel="stylesheet">

--- a/docs/getting-started/streaming/index.html
+++ b/docs/getting-started/streaming/index.html
@@ -5,7 +5,6 @@
     
       <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
-<meta name="revised" content="2019-03-26T21:27:36 IST">
 <title>Streaming Recognition :: Cubic SDK -- Cobalt</title>
 <link rel="shortcut icon" href="/sdk-cubic/images/favicon.ico" type="image/x-icon" />
 <link href="/sdk-cubic/css/nucleus.css" rel="stylesheet">

--- a/docs/index.html
+++ b/docs/index.html
@@ -6,7 +6,6 @@
     
       <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
-<meta name="revised" content="2019-03-26T21:27:36 IST">
 <title>Cubic SDK Documentation :: Cubic SDK -- Cobalt</title>
 <link rel="shortcut icon" href="/sdk-cubic/images/favicon.ico" type="image/x-icon" />
 <link href="/sdk-cubic/css/nucleus.css" rel="stylesheet">

--- a/docs/protobuf/autogen-doc-cubic-proto/index.html
+++ b/docs/protobuf/autogen-doc-cubic-proto/index.html
@@ -5,7 +5,6 @@
     
       <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
-<meta name="revised" content="2019-03-26T21:27:36 IST">
 <title>Proto Generated Docs :: Cubic SDK -- Cobalt</title>
 <link rel="shortcut icon" href="/sdk-cubic/images/favicon.ico" type="image/x-icon" />
 <link href="/sdk-cubic/css/nucleus.css" rel="stylesheet">

--- a/docs/protobuf/index.html
+++ b/docs/protobuf/index.html
@@ -5,7 +5,6 @@
     
       <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
-<meta name="revised" content="2019-03-26T21:27:36 IST">
 <title>Protobuf Reference :: Cubic SDK -- Cobalt</title>
 <link rel="shortcut icon" href="/sdk-cubic/images/favicon.ico" type="image/x-icon" />
 <link href="/sdk-cubic/css/nucleus.css" rel="stylesheet">

--- a/docs/tags/index.html
+++ b/docs/tags/index.html
@@ -5,7 +5,6 @@
     
       <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
-<meta name="revised" content="2019-03-26T21:27:36 IST">
 <title>Tags :: Cubic SDK -- Cobalt</title>
 <link rel="shortcut icon" href="/sdk-cubic/images/favicon.ico" type="image/x-icon" />
 <link href="/sdk-cubic/css/nucleus.css" rel="stylesheet">


### PR DESCRIPTION
The "head" template for generating content was adding a "revised" timestamp for
all files, causing an update to the generated files even if the actual sources
did not change.  This removes that timestamp.