### PR TITLE
docs: fix pip install command

### DIFF
--- a/docs-src/content/getting-started/installation.md
+++ b/docs-src/content/getting-started/installation.md
@@ -20,5 +20,5 @@ The Python SDK depends on Python >= 3.5. You may use pip to perform a system-wid
 
 ``` bash
 pip install --upgrade pip
-pip install git+https://github.com/cobaltspeech/sdk-cubic/grpc/py-cubic#egg=cobalt-cubic
+pip install "git+https://github.com/cobaltspeech/sdk-cubic#egg=cobalt-cubic&subdirectory=grpc/py-cubic"
 ```

--- a/docs/getting-started/installation/index.html
+++ b/docs/getting-started/installation/index.html
@@ -216,7 +216,7 @@ import this package into your application:</p>
 
 <p>The Python SDK depends on Python &gt;= 3.5. You may use pip to perform a system-wide install, or use virtualenv for a local install.</p>
 <div class="highlight"><pre style="color:#d0d0d0;background-color:#202020;-moz-tab-size:4;-o-tab-size:4;tab-size:4"><code class="language-bash" data-lang="bash">pip install --upgrade pip
-pip install git+https://github.com/cobaltspeech/sdk-cubic/grpc/py-cubic#egg=cobalt-cubic</code></pre></div>
+pip install <span style="color:#ed9d13">&#34;git+https://github.com/cobaltspeech/sdk-cubic#egg=cobalt-cubic&amp;subdirectory=grpc/py-cubic&#34;</span></code></pre></div>
 
     
     

--- a/docs/index.json
+++ b/docs/index.json
@@ -11,7 +11,7 @@
 	"title": "Installation",
 	"tags": [],
 	"description": "",
-	"content": "Instructions for installing the SDK are language specific.\nGo The Go SDK supports Go modules and requires Go 1.12 or later. To use the SDK, import this package into your application:\nimport \u0026#34;github.com/cobaltspeech/sdk-cubic/grpc/go-cubic\u0026#34; Python The Python SDK depends on Python \u0026gt;= 3.5. You may use pip to perform a system-wide install, or use virtualenv for a local install.\npip install --upgrade pip pip install git+https://github.com/cobaltspeech/sdk-cubic/grpc/py-cubic#egg=cobalt-cubic"
+	"content": "Instructions for installing the SDK are language specific.\nGo The Go SDK supports Go modules and requires Go 1.12 or later. To use the SDK, import this package into your application:\nimport \u0026#34;github.com/cobaltspeech/sdk-cubic/grpc/go-cubic\u0026#34; Python The Python SDK depends on Python \u0026gt;= 3.5. You may use pip to perform a system-wide install, or use virtualenv for a local install.\npip install --upgrade pip pip install \u0026#34;git+https://github.com/cobaltspeech/sdk-cubic#egg=cobalt-cubic\u0026amp;subdirectory=grpc/py-cubic\u0026#34;"
 },
 {
 	"uri": "https://cobaltspeech.github.io/sdk-cubic/protobuf/",


### PR DESCRIPTION
The link for the `pip install` command for python sdk needed to have the subdirectory (`grpc/py-cubic`) where setup.py was specified