### PR TITLE
fix: autogenerated page title

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-	<meta name="generator" content="Hugo 0.55.1" />
+	<meta name="generator" content="Hugo 0.55.4" />
     <title>Cubic SDK -- Cobalt</title>
     
       <meta charset="utf-8">

--- a/grpc/doc.md.tmpl
+++ b/grpc/doc.md.tmpl
@@ -1,5 +1,5 @@
 ---
-title: "Proto Generated Docs"
+title: "Cubic Protobuf API Docs"
 weight: 100
 ---
 


### PR DESCRIPTION
Page title for the cubic protobuf api docs is now updated in the
template file, so regenerating docs produces the correct result.