### PR TITLE
Add docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ serve it locally:
 
 ```
 cd docs-src
-hugo server -D
+../deps/bin/hugo server -D
 ```
 
 ### Tagging New Versions

--- a/ci/validate_generated_artifacts.sh
+++ b/ci/validate_generated_artifacts.sh
@@ -10,4 +10,4 @@ apt update && apt install -y python3 python-virtualenv unzip
 make
 
 # it's an error if we generated something that wasn't checked in.
-git diff --quiet || exit 1
+git diff --name-only --exit-code || (echo "Not all generated files were checked in" && exit 1)

--- a/docs-src/content/getting-started/cubic-cli.md
+++ b/docs-src/content/getting-started/cubic-cli.md
@@ -1,0 +1,5 @@
+---
+title: "Cubic Command-line Interface"
+weight: 60
+---
+Cobalt provides a command-line interface built using our Go SDK to specify an audio file or list of files and get transcripts back from a running instance of cubicsvr. The [source code](https://github.com/cobaltspeech/cubic-cli) is available to use as an example client.

--- a/docs-src/content/getting-started/cubic_docker.md
+++ b/docs-src/content/getting-started/cubic_docker.md
@@ -1,0 +1,63 @@
+---
+title: Installing the cubicsvr Image
+weight: 5
+---
+
+The SDK is used to call an instance of cubicsvr using gRPC.  Cobalt distributes a docker image that contains the cubicsvr binary and model files.
+
+<!--more-->
+
+1. Contact Cobalt to get a link to the image file in AWS S3.  This link will expire in two weeks, so be sure to download the file to your own server.
+
+2. Download with the AWS CLI if you have it, or with curl:
+
+    ```bash
+    URL="the url sent by Cobalt"
+    IMAGE_NAME="name you want to give the file (should end with the same extension as the url, usually bz2)"
+    curl $URL -L -o $IMAGE_NAME
+    ```
+   
+2. Load the docker image: 
+
+    ```bash
+    docker load < $IMAGE_NAME
+    ```
+
+    This will output the name of the image (e.g. cubicsvr-demo-en_us-16).
+
+3. Start the cubic service listening:
+
+    ```bash
+    docker run -p 2727:2727 -p 8080:8080 --name cobalt cubicsvr-demo-en_us-16
+    ```
+
+    That will start listening for grpc commands on port 2727 and http requests on 8080, and will stream the debug log to stdout.  (You can replace `--name cobalt` with whatever name you want.  That just provides a way to refer back to the currently running container.)
+
+4. Verify the service is running by calling 
+
+    ```bash
+    curl http://localhost:8080/api/version
+    ```
+
+5. If you want to explore the package to see the model files etc, call the following to open the bash terminal on the previously run image.  Model files are located in the /model directory.
+   
+    ```bash
+    docker exec -it cobalt bash
+    ```
+   
+## Contents of the docker image
+- **Base docker image** : debian-stretch-slim
+- **Additional dependencies** (installed with yum install on centos or apt-get on ubuntu)
+    - libgfortran3
+    - sox
+
+#### Cobalt-specific files
+- **cubicsvr** - binary for performing Automatic Speech Recognition
+- **model.config** - top-level config
+- **am/nnet3_online/final.mdl** - this is the acoustic model
+- **am/nnet3_online/conf/online_cmvn.conf** - feature extraction parameters for the features fed into the GMM model used for i-vector statistics accumulation.
+- **am/nnet3_online/conf/splice.conf** - GMM feature context when accumulating statistics for i-vector accumulation. 
+- **am/nnet3_online/ivector_extractor/*** - Kaldi configuration files related to ivectors  
+- **graph/HCLG.fst** - the decoding graph: the combination of the AMs transition graph, the lexicon, and the language model
+- **graph/words.txt** - an integer to word mapping, needed because the output of the HCLG graph contains only integer symbol IDs
+- **graph/phones/word_boundary.int** - this is needed only when confusion network output is requested, it tells the decoder which phones are at word boundaries

--- a/docs-src/content/getting-started/installation.md
+++ b/docs-src/content/getting-started/installation.md
@@ -1,6 +1,6 @@
 ---
-title: "Installation"
-weight: 1
+title: "Installing the SDK"
+weight: 2
 ---
 
 Instructions for installing the SDK are language specific.

--- a/docs/404.html
+++ b/docs/404.html
@@ -79,7 +79,14 @@
       <li data-nav-id="/sdk-cubic/getting-started/installation/" class="dd-item">
         <div>
           <a href="/sdk-cubic/getting-started/installation/">
-            Installation
+            Installing the SDK
+          </a><i class="fa fa-circle-thin read-icon"></i>
+        </div>
+    </li>
+      <li data-nav-id="/sdk-cubic/getting-started/cubic_docker/" class="dd-item">
+        <div>
+          <a href="/sdk-cubic/getting-started/cubic_docker/">
+            Installing the cubicsvr Image
           </a><i class="fa fa-circle-thin read-icon"></i>
         </div>
     </li>
@@ -101,6 +108,13 @@
         <div>
           <a href="/sdk-cubic/getting-started/streaming/">
             Streaming Recognition
+          </a><i class="fa fa-circle-thin read-icon"></i>
+        </div>
+    </li>
+      <li data-nav-id="/sdk-cubic/getting-started/cubic-cli/" class="dd-item">
+        <div>
+          <a href="/sdk-cubic/getting-started/cubic-cli/">
+            Cubic Command-line Interface
           </a><i class="fa fa-circle-thin read-icon"></i>
         </div>
     </li>

--- a/docs/_header/index.html
+++ b/docs/_header/index.html
@@ -79,7 +79,14 @@
       <li data-nav-id="/sdk-cubic/getting-started/installation/" class="dd-item">
         <div>
           <a href="/sdk-cubic/getting-started/installation/">
-            Installation
+            Installing the SDK
+          </a><i class="fa fa-circle-thin read-icon"></i>
+        </div>
+    </li>
+      <li data-nav-id="/sdk-cubic/getting-started/cubic_docker/" class="dd-item">
+        <div>
+          <a href="/sdk-cubic/getting-started/cubic_docker/">
+            Installing the cubicsvr Image
           </a><i class="fa fa-circle-thin read-icon"></i>
         </div>
     </li>
@@ -101,6 +108,13 @@
         <div>
           <a href="/sdk-cubic/getting-started/streaming/">
             Streaming Recognition
+          </a><i class="fa fa-circle-thin read-icon"></i>
+        </div>
+    </li>
+      <li data-nav-id="/sdk-cubic/getting-started/cubic-cli/" class="dd-item">
+        <div>
+          <a href="/sdk-cubic/getting-started/cubic-cli/">
+            Cubic Command-line Interface
           </a><i class="fa fa-circle-thin read-icon"></i>
         </div>
     </li>

--- a/docs/categories/index.html
+++ b/docs/categories/index.html
@@ -79,7 +79,14 @@
       <li data-nav-id="/sdk-cubic/getting-started/installation/" class="dd-item">
         <div>
           <a href="/sdk-cubic/getting-started/installation/">
-            Installation
+            Installing the SDK
+          </a><i class="fa fa-circle-thin read-icon"></i>
+        </div>
+    </li>
+      <li data-nav-id="/sdk-cubic/getting-started/cubic_docker/" class="dd-item">
+        <div>
+          <a href="/sdk-cubic/getting-started/cubic_docker/">
+            Installing the cubicsvr Image
           </a><i class="fa fa-circle-thin read-icon"></i>
         </div>
     </li>
@@ -101,6 +108,13 @@
         <div>
           <a href="/sdk-cubic/getting-started/streaming/">
             Streaming Recognition
+          </a><i class="fa fa-circle-thin read-icon"></i>
+        </div>
+    </li>
+      <li data-nav-id="/sdk-cubic/getting-started/cubic-cli/" class="dd-item">
+        <div>
+          <a href="/sdk-cubic/getting-started/cubic-cli/">
+            Cubic Command-line Interface
           </a><i class="fa fa-circle-thin read-icon"></i>
         </div>
     </li>

--- a/docs/getting-started/connecting/index.html
+++ b/docs/getting-started/connecting/index.html
@@ -79,7 +79,14 @@
       <li data-nav-id="/sdk-cubic/getting-started/installation/" class="dd-item">
         <div>
           <a href="/sdk-cubic/getting-started/installation/">
-            Installation
+            Installing the SDK
+          </a><i class="fa fa-circle-thin read-icon"></i>
+        </div>
+    </li>
+      <li data-nav-id="/sdk-cubic/getting-started/cubic_docker/" class="dd-item">
+        <div>
+          <a href="/sdk-cubic/getting-started/cubic_docker/">
+            Installing the cubicsvr Image
           </a><i class="fa fa-circle-thin read-icon"></i>
         </div>
     </li>
@@ -101,6 +108,13 @@
         <div>
           <a href="/sdk-cubic/getting-started/streaming/">
             Streaming Recognition
+          </a><i class="fa fa-circle-thin read-icon"></i>
+        </div>
+    </li>
+      <li data-nav-id="/sdk-cubic/getting-started/cubic-cli/" class="dd-item">
+        <div>
+          <a href="/sdk-cubic/getting-started/cubic-cli/">
+            Cubic Command-line Interface
           </a><i class="fa fa-circle-thin read-icon"></i>
         </div>
     </li>
@@ -329,7 +343,7 @@ provided to you.</p>
 </div>
 
 <div id="navigation">
-<a class="nav nav-prev" href="/sdk-cubic/getting-started/installation/" title="Installation"> <i class="fa fa-chevron-left"></i><label>Installation</label></a>
+<a class="nav nav-prev" href="/sdk-cubic/getting-started/cubic_docker/" title="Installing the cubicsvr Image"> <i class="fa fa-chevron-left"></i><label>Installing the cubicsvr Image</label></a>
     <a class="nav nav-next" href="/sdk-cubic/getting-started/recognize/" title="Synchronous Recognition" style="margin-right: 0px;"><label>Synchronous Recognition</label><i class="fa fa-chevron-right"></i></a></div>
 
 </section>

--- a/docs/getting-started/cubic-cli/index.html
+++ b/docs/getting-started/cubic-cli/index.html
@@ -5,7 +5,7 @@
     
       <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
-<title>Synchronous Recognition :: Cubic SDK -- Cobalt</title>
+<title>Cubic Command-line Interface :: Cubic SDK -- Cobalt</title>
 <link rel="shortcut icon" href="/sdk-cubic/images/favicon.ico" type="image/x-icon" />
 <link href="/sdk-cubic/css/nucleus.css" rel="stylesheet">
 <link href="/sdk-cubic/css/font-awesome.min.css" rel="stylesheet">
@@ -29,7 +29,7 @@
 
     
   </head>
-  <body data-url="/sdk-cubic/getting-started/recognize/">
+  <body data-url="/sdk-cubic/getting-started/cubic-cli/">
     
       <div id="headermain"></div>
 <nav id="sidebar" class="showVisitedLinks">
@@ -97,7 +97,7 @@
           </a><i class="fa fa-circle-thin read-icon"></i>
         </div>
     </li>
-      <li data-nav-id="/sdk-cubic/getting-started/recognize/" class="dd-item active">
+      <li data-nav-id="/sdk-cubic/getting-started/recognize/" class="dd-item">
         <div>
           <a href="/sdk-cubic/getting-started/recognize/">
             Synchronous Recognition
@@ -111,7 +111,7 @@
           </a><i class="fa fa-circle-thin read-icon"></i>
         </div>
     </li>
-      <li data-nav-id="/sdk-cubic/getting-started/cubic-cli/" class="dd-item">
+      <li data-nav-id="/sdk-cubic/getting-started/cubic-cli/" class="dd-item active">
         <div>
           <a href="/sdk-cubic/getting-started/cubic-cli/">
             Cubic Command-line Interface
@@ -177,7 +177,7 @@
 
 
 
- <a href='/sdk-cubic/'>Cubic SDK Documentation</a> > <a href='/sdk-cubic/getting-started/'>Getting started</a> > Synchronous Recognition
+ <a href='/sdk-cubic/'>Cubic SDK Documentation</a> > <a href='/sdk-cubic/getting-started/'>Getting started</a> > Cubic Command-line Interface
 
  
 
@@ -200,7 +200,7 @@
 
 <div id="body-inner">
   
-    <h1>Synchronous Recognition</h1>
+    <h1>Cubic Command-line Interface</h1>
   
 
 
@@ -208,102 +208,8 @@
     
     
     
-    <p>The following example shows how to transcribe a short audio clip using Cubic&rsquo;s
-Synchoronous Recognize Request. It is assumed that the audio file contains raw
-samples, PCM16SLE like Cubic expects.  We will query the server for available
-models and use the first model to transcribe this speech.</p>
+    <p>Cobalt provides a command-line interface built using our Go SDK to specify an audio file or list of files and get transcripts back from a running instance of cubicsvr. The <a href="https://github.com/cobaltspeech/cubic-cli">source code</a> is available to use as an example client.</p>
 
-<p>Synchronous recognize requests are suitable only for audio clips shorter than 30
-seconds. In general, it is strongly recommended that you use streaming
-recognition.</p>
-
-<div class='code-tabs'>
-  <ul class="nav-tabs"></ul>
-  <div class="tab-content">
-
-<div class="tab-pane" title="Go">
-  <div class="highlight"><pre style="color:#d0d0d0;background-color:#202020;-moz-tab-size:4;-o-tab-size:4;tab-size:4"><code class="language-go" data-lang="go"><span style="color:#6ab825;font-weight:bold">package</span> main
-
-<span style="color:#6ab825;font-weight:bold">import</span> (
-    <span style="color:#ed9d13">&#34;context&#34;</span>
-    <span style="color:#ed9d13">&#34;fmt&#34;</span>
-    <span style="color:#ed9d13">&#34;log&#34;</span>
-    <span style="color:#ed9d13">&#34;os&#34;</span>
-
-    <span style="color:#ed9d13">&#34;github.com/cobaltspeech/sdk-cubic/grpc/go-cubic&#34;</span>
-    <span style="color:#ed9d13">&#34;github.com/cobaltspeech/sdk-cubic/grpc/go-cubic/cubicpb&#34;</span>
-)
-
-<span style="color:#6ab825;font-weight:bold">const</span> serverAddr = <span style="color:#ed9d13">&#34;127.0.0.1:2727&#34;</span>
-
-<span style="color:#6ab825;font-weight:bold">func</span> <span style="color:#447fcf">main</span>() {
-    client, err := cubic.<span style="color:#447fcf">NewClient</span>(serverAddr)
-    <span style="color:#6ab825;font-weight:bold">if</span> err != <span style="color:#6ab825;font-weight:bold">nil</span> {
-        log.<span style="color:#447fcf">Fatal</span>(err)
-    }
-    <span style="color:#6ab825;font-weight:bold">defer</span> client.<span style="color:#447fcf">Close</span>()
-
-    modelResp, err := client.<span style="color:#447fcf">ListModels</span>(context.<span style="color:#447fcf">Background</span>())
-    <span style="color:#6ab825;font-weight:bold">if</span> err != <span style="color:#6ab825;font-weight:bold">nil</span> {
-        log.<span style="color:#447fcf">Fatal</span>(err)
-    }
-
-    <span style="color:#999;font-style:italic">// Use the first available model
-</span><span style="color:#999;font-style:italic"></span>   model := modelResp.Models[<span style="color:#3677a9">0</span>]
-
-    f, err := os.<span style="color:#447fcf">Open</span>(<span style="color:#ed9d13">&#34;test.raw&#34;</span>)
-    <span style="color:#6ab825;font-weight:bold">if</span> err != <span style="color:#6ab825;font-weight:bold">nil</span> {
-        log.<span style="color:#447fcf">Fatal</span>(err)
-    }
-
-    <span style="color:#6ab825;font-weight:bold">defer</span> f.<span style="color:#447fcf">Close</span>()
-
-    cfg := &amp;cubicpb.RecognitionConfig{
-        ModelId: model.Id,
-    }
-
-    recResp, err := client.<span style="color:#447fcf">Recognize</span>(context.<span style="color:#447fcf">Background</span>(), cfg, f)
-
-    <span style="color:#6ab825;font-weight:bold">for</span> _, r := <span style="color:#6ab825;font-weight:bold">range</span> recResp.Results {
-        <span style="color:#6ab825;font-weight:bold">if</span> !r.IsPartial {
-            fmt.<span style="color:#447fcf">Println</span>(r.Alternatives[<span style="color:#3677a9">0</span>].Transcript)
-        }
-    }
-
-}</code></pre></div>
-</div>
-
-<div class="tab-pane" title="Python">
-  <div class="highlight"><pre style="color:#d0d0d0;background-color:#202020;-moz-tab-size:4;-o-tab-size:4;tab-size:4"><code class="language-python" data-lang="python"><span style="color:#6ab825;font-weight:bold">import</span> <span style="color:#447fcf;text-decoration:underline">cubic</span>
-
-serverAddress = <span style="color:#ed9d13">&#39;127.0.0.1:2727&#39;</span>
-
-client = cubic.Client(serverAddress)
-
-<span style="color:#999;font-style:italic"># get list of available models</span>
-modelResp = client.ListModels()
-<span style="color:#6ab825;font-weight:bold">for</span> model <span style="color:#6ab825;font-weight:bold">in</span> modelResp.models:
-    <span style="color:#6ab825;font-weight:bold">print</span>(<span style="color:#ed9d13">&#34;ID = {}, Name = {}&#34;</span>.format(model.<span style="color:#24909d">id</span>, model.name))
-
-<span style="color:#999;font-style:italic"># use the first available model</span>
-model = modelResp.models[<span style="color:#3677a9">0</span>]
-
-cfg = cubic.RecognitionConfig(
-    model_id = model.<span style="color:#24909d">id</span>
-)
-
-<span style="color:#999;font-style:italic"># open audio file </span>
-audio = <span style="color:#24909d">open</span>(<span style="color:#ed9d13">&#39;test.raw&#39;</span>, <span style="color:#ed9d13">&#39;rb&#39;</span>)
-
-resp = client.Recognize(cfg, audio)
-
-<span style="color:#6ab825;font-weight:bold">for</span> result <span style="color:#6ab825;font-weight:bold">in</span> resp.results:
-    <span style="color:#6ab825;font-weight:bold">if</span> <span style="color:#6ab825;font-weight:bold">not</span> result.is_partial:
-        <span style="color:#6ab825;font-weight:bold">print</span>(result.alternatives[<span style="color:#3677a9">0</span>].transcript)</code></pre></div>
-</div>
-
-<p></div>
-</div></p>
 
     
     
@@ -314,8 +220,8 @@ resp = client.Recognize(cfg, audio)
 </div>
 
 <div id="navigation">
-<a class="nav nav-prev" href="/sdk-cubic/getting-started/connecting/" title="Setup Connection"> <i class="fa fa-chevron-left"></i><label>Setup Connection</label></a>
-    <a class="nav nav-next" href="/sdk-cubic/getting-started/streaming/" title="Streaming Recognition" style="margin-right: 0px;"><label>Streaming Recognition</label><i class="fa fa-chevron-right"></i></a></div>
+<a class="nav nav-prev" href="/sdk-cubic/getting-started/streaming/" title="Streaming Recognition"> <i class="fa fa-chevron-left"></i><label>Streaming Recognition</label></a>
+    <a class="nav nav-next" href="/sdk-cubic/protobuf/" title="Cubic API Reference" style="margin-right: 0px;"><label>Cubic API Reference</label><i class="fa fa-chevron-right"></i></a></div>
 
 </section>
 <div style="left: -1000px; overflow: scroll; position: absolute; top: -1000px; border: none; box-sizing: content-box; height: 200px; margin: 0px; padding: 0px; width: 200px;">

--- a/docs/getting-started/cubic_docker/index.html
+++ b/docs/getting-started/cubic_docker/index.html
@@ -5,7 +5,7 @@
     
       <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
-<title>Synchronous Recognition :: Cubic SDK -- Cobalt</title>
+<title>Installing the cubicsvr Image :: Cubic SDK -- Cobalt</title>
 <link rel="shortcut icon" href="/sdk-cubic/images/favicon.ico" type="image/x-icon" />
 <link href="/sdk-cubic/css/nucleus.css" rel="stylesheet">
 <link href="/sdk-cubic/css/font-awesome.min.css" rel="stylesheet">
@@ -29,7 +29,7 @@
 
     
   </head>
-  <body data-url="/sdk-cubic/getting-started/recognize/">
+  <body data-url="/sdk-cubic/getting-started/cubic_docker/">
     
       <div id="headermain"></div>
 <nav id="sidebar" class="showVisitedLinks">
@@ -83,7 +83,7 @@
           </a><i class="fa fa-circle-thin read-icon"></i>
         </div>
     </li>
-      <li data-nav-id="/sdk-cubic/getting-started/cubic_docker/" class="dd-item">
+      <li data-nav-id="/sdk-cubic/getting-started/cubic_docker/" class="dd-item active">
         <div>
           <a href="/sdk-cubic/getting-started/cubic_docker/">
             Installing the cubicsvr Image
@@ -97,7 +97,7 @@
           </a><i class="fa fa-circle-thin read-icon"></i>
         </div>
     </li>
-      <li data-nav-id="/sdk-cubic/getting-started/recognize/" class="dd-item active">
+      <li data-nav-id="/sdk-cubic/getting-started/recognize/" class="dd-item">
         <div>
           <a href="/sdk-cubic/getting-started/recognize/">
             Synchronous Recognition
@@ -177,7 +177,7 @@
 
 
 
- <a href='/sdk-cubic/'>Cubic SDK Documentation</a> > <a href='/sdk-cubic/getting-started/'>Getting started</a> > Synchronous Recognition
+ <a href='/sdk-cubic/'>Cubic SDK Documentation</a> > <a href='/sdk-cubic/getting-started/'>Getting started</a> > Installing the cubicsvr Image
 
  
 
@@ -190,7 +190,20 @@
     
     <div class="progress">
         <div class="wrapper">
-    
+    <nav id="TableOfContents">
+<ul>
+<li>
+<ul>
+<li><a href="#contents-of-the-docker-image">Contents of the docker image</a>
+<ul>
+<li>
+<ul>
+<li><a href="#cobalt-specific-files">Cobalt-specific files</a></li>
+</ul></li>
+</ul></li>
+</ul></li>
+</ul>
+</nav>
         </div>
     </div>
     
@@ -200,7 +213,7 @@
 
 <div id="body-inner">
   
-    <h1>Synchronous Recognition</h1>
+    <h1>Installing the cubicsvr Image</h1>
   
 
 
@@ -208,102 +221,56 @@
     
     
     
-    <p>The following example shows how to transcribe a short audio clip using Cubic&rsquo;s
-Synchoronous Recognize Request. It is assumed that the audio file contains raw
-samples, PCM16SLE like Cubic expects.  We will query the server for available
-models and use the first model to transcribe this speech.</p>
+    <p>The SDK is used to call an instance of cubicsvr using gRPC.  Cobalt distributes a docker image that contains the cubicsvr binary and model files.</p>
 
-<p>Synchronous recognize requests are suitable only for audio clips shorter than 30
-seconds. In general, it is strongly recommended that you use streaming
-recognition.</p>
+<ol>
+<li><p>Contact Cobalt to get a link to the image file in AWS S3.  This link will expire in two weeks, so be sure to download the file to your own server.</p></li>
 
-<div class='code-tabs'>
-  <ul class="nav-tabs"></ul>
-  <div class="tab-content">
+<li><p>Download with the AWS CLI if you have it, or with curl:</p>
+<div class="highlight"><pre style="color:#d0d0d0;background-color:#202020;-moz-tab-size:4;-o-tab-size:4;tab-size:4"><code class="language-bash" data-lang="bash"><span style="color:#40ffff">URL</span>=<span style="color:#ed9d13">&#34;the url sent by Cobalt&#34;</span>
+<span style="color:#40ffff">IMAGE_NAME</span>=<span style="color:#ed9d13">&#34;name you want to give the file (should end with the same extension as the url, usually bz2)&#34;</span>
+curl <span style="color:#40ffff">$URL</span> -L -o <span style="color:#40ffff">$IMAGE_NAME</span></code></pre></div></li>
 
-<div class="tab-pane" title="Go">
-  <div class="highlight"><pre style="color:#d0d0d0;background-color:#202020;-moz-tab-size:4;-o-tab-size:4;tab-size:4"><code class="language-go" data-lang="go"><span style="color:#6ab825;font-weight:bold">package</span> main
+<li><p>Load the docker image:</p>
+<div class="highlight"><pre style="color:#d0d0d0;background-color:#202020;-moz-tab-size:4;-o-tab-size:4;tab-size:4"><code class="language-bash" data-lang="bash">docker load &lt; <span style="color:#40ffff">$IMAGE_NAME</span></code></pre></div>
+<p>This will output the name of the image (e.g. cubicsvr-demo-en_us-16).</p></li>
 
-<span style="color:#6ab825;font-weight:bold">import</span> (
-    <span style="color:#ed9d13">&#34;context&#34;</span>
-    <span style="color:#ed9d13">&#34;fmt&#34;</span>
-    <span style="color:#ed9d13">&#34;log&#34;</span>
-    <span style="color:#ed9d13">&#34;os&#34;</span>
+<li><p>Start the cubic service listening:</p>
+<div class="highlight"><pre style="color:#d0d0d0;background-color:#202020;-moz-tab-size:4;-o-tab-size:4;tab-size:4"><code class="language-bash" data-lang="bash">docker run -p <span style="color:#3677a9">2727</span>:2727 -p <span style="color:#3677a9">8080</span>:8080 --name cobalt cubicsvr-demo-en_us-16</code></pre></div>
+<p>That will start listening for grpc commands on port 2727 and http requests on 8080, and will stream the debug log to stdout.  (You can replace <code>--name cobalt</code> with whatever name you want.  That just provides a way to refer back to the currently running container.)</p></li>
 
-    <span style="color:#ed9d13">&#34;github.com/cobaltspeech/sdk-cubic/grpc/go-cubic&#34;</span>
-    <span style="color:#ed9d13">&#34;github.com/cobaltspeech/sdk-cubic/grpc/go-cubic/cubicpb&#34;</span>
-)
+<li><p>Verify the service is running by calling</p>
+<div class="highlight"><pre style="color:#d0d0d0;background-color:#202020;-moz-tab-size:4;-o-tab-size:4;tab-size:4"><code class="language-bash" data-lang="bash">curl http://localhost:8080/api/version</code></pre></div></li>
 
-<span style="color:#6ab825;font-weight:bold">const</span> serverAddr = <span style="color:#ed9d13">&#34;127.0.0.1:2727&#34;</span>
+<li><p>If you want to explore the package to see the model files etc, call the following to open the bash terminal on the previously run image.  Model files are located in the /model directory.</p>
+<div class="highlight"><pre style="color:#d0d0d0;background-color:#202020;-moz-tab-size:4;-o-tab-size:4;tab-size:4"><code class="language-bash" data-lang="bash">docker <span style="color:#24909d">exec</span> -it cobalt bash</code></pre></div></li>
+</ol>
 
-<span style="color:#6ab825;font-weight:bold">func</span> <span style="color:#447fcf">main</span>() {
-    client, err := cubic.<span style="color:#447fcf">NewClient</span>(serverAddr)
-    <span style="color:#6ab825;font-weight:bold">if</span> err != <span style="color:#6ab825;font-weight:bold">nil</span> {
-        log.<span style="color:#447fcf">Fatal</span>(err)
-    }
-    <span style="color:#6ab825;font-weight:bold">defer</span> client.<span style="color:#447fcf">Close</span>()
+<h2 id="contents-of-the-docker-image">Contents of the docker image</h2>
 
-    modelResp, err := client.<span style="color:#447fcf">ListModels</span>(context.<span style="color:#447fcf">Background</span>())
-    <span style="color:#6ab825;font-weight:bold">if</span> err != <span style="color:#6ab825;font-weight:bold">nil</span> {
-        log.<span style="color:#447fcf">Fatal</span>(err)
-    }
+<ul>
+<li><strong>Base docker image</strong> : debian-stretch-slim</li>
+<li><strong>Additional dependencies</strong> (installed with yum install on centos or apt-get on ubuntu)
 
-    <span style="color:#999;font-style:italic">// Use the first available model
-</span><span style="color:#999;font-style:italic"></span>   model := modelResp.Models[<span style="color:#3677a9">0</span>]
+<ul>
+<li>libgfortran3</li>
+<li>sox</li>
+</ul></li>
+</ul>
 
-    f, err := os.<span style="color:#447fcf">Open</span>(<span style="color:#ed9d13">&#34;test.raw&#34;</span>)
-    <span style="color:#6ab825;font-weight:bold">if</span> err != <span style="color:#6ab825;font-weight:bold">nil</span> {
-        log.<span style="color:#447fcf">Fatal</span>(err)
-    }
+<h4 id="cobalt-specific-files">Cobalt-specific files</h4>
 
-    <span style="color:#6ab825;font-weight:bold">defer</span> f.<span style="color:#447fcf">Close</span>()
-
-    cfg := &amp;cubicpb.RecognitionConfig{
-        ModelId: model.Id,
-    }
-
-    recResp, err := client.<span style="color:#447fcf">Recognize</span>(context.<span style="color:#447fcf">Background</span>(), cfg, f)
-
-    <span style="color:#6ab825;font-weight:bold">for</span> _, r := <span style="color:#6ab825;font-weight:bold">range</span> recResp.Results {
-        <span style="color:#6ab825;font-weight:bold">if</span> !r.IsPartial {
-            fmt.<span style="color:#447fcf">Println</span>(r.Alternatives[<span style="color:#3677a9">0</span>].Transcript)
-        }
-    }
-
-}</code></pre></div>
-</div>
-
-<div class="tab-pane" title="Python">
-  <div class="highlight"><pre style="color:#d0d0d0;background-color:#202020;-moz-tab-size:4;-o-tab-size:4;tab-size:4"><code class="language-python" data-lang="python"><span style="color:#6ab825;font-weight:bold">import</span> <span style="color:#447fcf;text-decoration:underline">cubic</span>
-
-serverAddress = <span style="color:#ed9d13">&#39;127.0.0.1:2727&#39;</span>
-
-client = cubic.Client(serverAddress)
-
-<span style="color:#999;font-style:italic"># get list of available models</span>
-modelResp = client.ListModels()
-<span style="color:#6ab825;font-weight:bold">for</span> model <span style="color:#6ab825;font-weight:bold">in</span> modelResp.models:
-    <span style="color:#6ab825;font-weight:bold">print</span>(<span style="color:#ed9d13">&#34;ID = {}, Name = {}&#34;</span>.format(model.<span style="color:#24909d">id</span>, model.name))
-
-<span style="color:#999;font-style:italic"># use the first available model</span>
-model = modelResp.models[<span style="color:#3677a9">0</span>]
-
-cfg = cubic.RecognitionConfig(
-    model_id = model.<span style="color:#24909d">id</span>
-)
-
-<span style="color:#999;font-style:italic"># open audio file </span>
-audio = <span style="color:#24909d">open</span>(<span style="color:#ed9d13">&#39;test.raw&#39;</span>, <span style="color:#ed9d13">&#39;rb&#39;</span>)
-
-resp = client.Recognize(cfg, audio)
-
-<span style="color:#6ab825;font-weight:bold">for</span> result <span style="color:#6ab825;font-weight:bold">in</span> resp.results:
-    <span style="color:#6ab825;font-weight:bold">if</span> <span style="color:#6ab825;font-weight:bold">not</span> result.is_partial:
-        <span style="color:#6ab825;font-weight:bold">print</span>(result.alternatives[<span style="color:#3677a9">0</span>].transcript)</code></pre></div>
-</div>
-
-<p></div>
-</div></p>
+<ul>
+<li><strong>cubicsvr</strong> - binary for performing Automatic Speech Recognition</li>
+<li><strong>model.config</strong> - top-level config</li>
+<li><strong>am/nnet3_online/final.mdl</strong> - this is the acoustic model</li>
+<li><strong>am/nnet3_online/conf/online_cmvn.conf</strong> - feature extraction parameters for the features fed into the GMM model used for i-vector statistics accumulation.</li>
+<li><strong>am/nnet3_online/conf/splice.conf</strong> - GMM feature context when accumulating statistics for i-vector accumulation.</li>
+<li><strong>am/nnet3_online/ivector_extractor/</strong>* - Kaldi configuration files related to ivectors<br /></li>
+<li><strong>graph/HCLG.fst</strong> - the decoding graph: the combination of the AMs transition graph, the lexicon, and the language model</li>
+<li><strong>graph/words.txt</strong> - an integer to word mapping, needed because the output of the HCLG graph contains only integer symbol IDs</li>
+<li><strong>graph/phones/word_boundary.int</strong> - this is needed only when confusion network output is requested, it tells the decoder which phones are at word boundaries</li>
+</ul>
 
     
     
@@ -314,8 +281,8 @@ resp = client.Recognize(cfg, audio)
 </div>
 
 <div id="navigation">
-<a class="nav nav-prev" href="/sdk-cubic/getting-started/connecting/" title="Setup Connection"> <i class="fa fa-chevron-left"></i><label>Setup Connection</label></a>
-    <a class="nav nav-next" href="/sdk-cubic/getting-started/streaming/" title="Streaming Recognition" style="margin-right: 0px;"><label>Streaming Recognition</label><i class="fa fa-chevron-right"></i></a></div>
+<a class="nav nav-prev" href="/sdk-cubic/getting-started/installation/" title="Installing the SDK"> <i class="fa fa-chevron-left"></i><label>Installing the SDK</label></a>
+    <a class="nav nav-next" href="/sdk-cubic/getting-started/connecting/" title="Setup Connection" style="margin-right: 0px;"><label>Setup Connection</label><i class="fa fa-chevron-right"></i></a></div>
 
 </section>
 <div style="left: -1000px; overflow: scroll; position: absolute; top: -1000px; border: none; box-sizing: content-box; height: 200px; margin: 0px; padding: 0px; width: 200px;">

--- a/docs/getting-started/index.html
+++ b/docs/getting-started/index.html
@@ -79,7 +79,14 @@
       <li data-nav-id="/sdk-cubic/getting-started/installation/" class="dd-item">
         <div>
           <a href="/sdk-cubic/getting-started/installation/">
-            Installation
+            Installing the SDK
+          </a><i class="fa fa-circle-thin read-icon"></i>
+        </div>
+    </li>
+      <li data-nav-id="/sdk-cubic/getting-started/cubic_docker/" class="dd-item">
+        <div>
+          <a href="/sdk-cubic/getting-started/cubic_docker/">
+            Installing the cubicsvr Image
           </a><i class="fa fa-circle-thin read-icon"></i>
         </div>
     </li>
@@ -101,6 +108,13 @@
         <div>
           <a href="/sdk-cubic/getting-started/streaming/">
             Streaming Recognition
+          </a><i class="fa fa-circle-thin read-icon"></i>
+        </div>
+    </li>
+      <li data-nav-id="/sdk-cubic/getting-started/cubic-cli/" class="dd-item">
+        <div>
+          <a href="/sdk-cubic/getting-started/cubic-cli/">
+            Cubic Command-line Interface
           </a><i class="fa fa-circle-thin read-icon"></i>
         </div>
     </li>
@@ -204,10 +218,27 @@
 
    <article class="post getting-started">
     <header class="post-header">
-        <h2 class="post-title"><a href="/sdk-cubic/getting-started/installation/">Installation</a></h2>
+        <h2 class="post-title"><a href="/sdk-cubic/getting-started/installation/">Installing the SDK</a></h2>
     </header>
     <section class="post-excerpt">
         <p><p>Instructions for installing the SDK are language specific.</p> <a class="read-more" href="/sdk-cubic/getting-started/installation/">&raquo;</a></p>
+    </section>
+    <footer class=" footline" >
+         
+        
+
+        
+        
+
+    </footer>
+</article>
+
+   <article class="post getting-started">
+    <header class="post-header">
+        <h2 class="post-title"><a href="/sdk-cubic/getting-started/cubic_docker/">Installing the cubicsvr Image</a></h2>
+    </header>
+    <section class="post-excerpt">
+        <p><p>The SDK is used to call an instance of cubicsvr using gRPC.  Cobalt distributes a docker image that contains the cubicsvr binary and model files.</p> <a class="read-more" href="/sdk-cubic/getting-started/cubic_docker/">&raquo;</a></p>
     </section>
     <footer class=" footline" >
          
@@ -281,6 +312,23 @@ use the first model to transcribe the speech.</p> <a class="read-more" href="/sd
     </footer>
 </article>
 
+   <article class="post getting-started">
+    <header class="post-header">
+        <h2 class="post-title"><a href="/sdk-cubic/getting-started/cubic-cli/">Cubic Command-line Interface</a></h2>
+    </header>
+    <section class="post-excerpt">
+        <p>Cobalt provides a command-line interface built using our Go SDK to specify an audio file or list of files and get transcripts back from a running instance of cubicsvr. The source code is available to use as an example client. <a class="read-more" href="/sdk-cubic/getting-started/cubic-cli/">&raquo;</a></p>
+    </section>
+    <footer class=" footline" >
+         
+        
+
+        
+        
+
+    </footer>
+</article>
+
 
 <div style="margin-bottom:2rem"></div>
 
@@ -303,7 +351,7 @@ use the first model to transcribe the speech.</p> <a class="read-more" href="/sd
 
 <div id="navigation">
 <a class="nav nav-prev" href="/sdk-cubic/" title="Cubic SDK Documentation"> <i class="fa fa-chevron-left"></i><label>Cubic SDK Documentation</label></a>
-    <a class="nav nav-next" href="/sdk-cubic/getting-started/installation/" title="Installation" style="margin-right: 0px;"><label>Installation</label><i class="fa fa-chevron-right"></i></a></div>
+    <a class="nav nav-next" href="/sdk-cubic/getting-started/installation/" title="Installing the SDK" style="margin-right: 0px;"><label>Installing the SDK</label><i class="fa fa-chevron-right"></i></a></div>
 
 </section>
 <div style="left: -1000px; overflow: scroll; position: absolute; top: -1000px; border: none; box-sizing: content-box; height: 200px; margin: 0px; padding: 0px; width: 200px;">

--- a/docs/getting-started/index.xml
+++ b/docs/getting-started/index.xml
@@ -11,12 +11,21 @@
     
     
     <item>
-      <title>Installation</title>
+      <title>Installing the SDK</title>
       <link>https://cobaltspeech.github.io/sdk-cubic/getting-started/installation/</link>
       <pubDate>Mon, 01 Jan 0001 00:00:00 +0000</pubDate>
       
       <guid>https://cobaltspeech.github.io/sdk-cubic/getting-started/installation/</guid>
       <description>&lt;p&gt;Instructions for installing the SDK are language specific.&lt;/p&gt;</description>
+    </item>
+    
+    <item>
+      <title>Installing the cubicsvr Image</title>
+      <link>https://cobaltspeech.github.io/sdk-cubic/getting-started/cubic_docker/</link>
+      <pubDate>Mon, 01 Jan 0001 00:00:00 +0000</pubDate>
+      
+      <guid>https://cobaltspeech.github.io/sdk-cubic/getting-started/cubic_docker/</guid>
+      <description>&lt;p&gt;The SDK is used to call an instance of cubicsvr using gRPC.  Cobalt distributes a docker image that contains the cubicsvr binary and model files.&lt;/p&gt;</description>
     </item>
     
     <item>
@@ -55,6 +64,15 @@ recognition.&lt;/p&gt;</description>
 Streaming Recognize Request. The example uses a WAV file as input to the
 streaming recognition. We will query the server for available models and
 use the first model to transcribe the speech.&lt;/p&gt;</description>
+    </item>
+    
+    <item>
+      <title>Cubic Command-line Interface</title>
+      <link>https://cobaltspeech.github.io/sdk-cubic/getting-started/cubic-cli/</link>
+      <pubDate>Mon, 01 Jan 0001 00:00:00 +0000</pubDate>
+      
+      <guid>https://cobaltspeech.github.io/sdk-cubic/getting-started/cubic-cli/</guid>
+      <description>Cobalt provides a command-line interface built using our Go SDK to specify an audio file or list of files and get transcripts back from a running instance of cubicsvr. The source code is available to use as an example client.</description>
     </item>
     
   </channel>

--- a/docs/getting-started/installation/index.html
+++ b/docs/getting-started/installation/index.html
@@ -5,7 +5,7 @@
     
       <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
-<title>Installation :: Cubic SDK -- Cobalt</title>
+<title>Installing the SDK :: Cubic SDK -- Cobalt</title>
 <link rel="shortcut icon" href="/sdk-cubic/images/favicon.ico" type="image/x-icon" />
 <link href="/sdk-cubic/css/nucleus.css" rel="stylesheet">
 <link href="/sdk-cubic/css/font-awesome.min.css" rel="stylesheet">
@@ -79,7 +79,14 @@
       <li data-nav-id="/sdk-cubic/getting-started/installation/" class="dd-item active">
         <div>
           <a href="/sdk-cubic/getting-started/installation/">
-            Installation
+            Installing the SDK
+          </a><i class="fa fa-circle-thin read-icon"></i>
+        </div>
+    </li>
+      <li data-nav-id="/sdk-cubic/getting-started/cubic_docker/" class="dd-item">
+        <div>
+          <a href="/sdk-cubic/getting-started/cubic_docker/">
+            Installing the cubicsvr Image
           </a><i class="fa fa-circle-thin read-icon"></i>
         </div>
     </li>
@@ -101,6 +108,13 @@
         <div>
           <a href="/sdk-cubic/getting-started/streaming/">
             Streaming Recognition
+          </a><i class="fa fa-circle-thin read-icon"></i>
+        </div>
+    </li>
+      <li data-nav-id="/sdk-cubic/getting-started/cubic-cli/" class="dd-item">
+        <div>
+          <a href="/sdk-cubic/getting-started/cubic-cli/">
+            Cubic Command-line Interface
           </a><i class="fa fa-circle-thin read-icon"></i>
         </div>
     </li>
@@ -163,7 +177,7 @@
 
 
 
- <a href='/sdk-cubic/'>Cubic SDK Documentation</a> > <a href='/sdk-cubic/getting-started/'>Getting started</a> > Installation
+ <a href='/sdk-cubic/'>Cubic SDK Documentation</a> > <a href='/sdk-cubic/getting-started/'>Getting started</a> > Installing the SDK
 
  
 
@@ -197,7 +211,7 @@
 
 <div id="body-inner">
   
-    <h1>Installation</h1>
+    <h1>Installing the SDK</h1>
   
 
 
@@ -228,7 +242,7 @@ pip install <span style="color:#ed9d13">&#34;git+https://github.com/cobaltspeech
 
 <div id="navigation">
 <a class="nav nav-prev" href="/sdk-cubic/getting-started/" title="Getting started"> <i class="fa fa-chevron-left"></i><label>Getting started</label></a>
-    <a class="nav nav-next" href="/sdk-cubic/getting-started/connecting/" title="Setup Connection" style="margin-right: 0px;"><label>Setup Connection</label><i class="fa fa-chevron-right"></i></a></div>
+    <a class="nav nav-next" href="/sdk-cubic/getting-started/cubic_docker/" title="Installing the cubicsvr Image" style="margin-right: 0px;"><label>Installing the cubicsvr Image</label><i class="fa fa-chevron-right"></i></a></div>
 
 </section>
 <div style="left: -1000px; overflow: scroll; position: absolute; top: -1000px; border: none; box-sizing: content-box; height: 200px; margin: 0px; padding: 0px; width: 200px;">

--- a/docs/getting-started/streaming/index.html
+++ b/docs/getting-started/streaming/index.html
@@ -79,7 +79,14 @@
       <li data-nav-id="/sdk-cubic/getting-started/installation/" class="dd-item">
         <div>
           <a href="/sdk-cubic/getting-started/installation/">
-            Installation
+            Installing the SDK
+          </a><i class="fa fa-circle-thin read-icon"></i>
+        </div>
+    </li>
+      <li data-nav-id="/sdk-cubic/getting-started/cubic_docker/" class="dd-item">
+        <div>
+          <a href="/sdk-cubic/getting-started/cubic_docker/">
+            Installing the cubicsvr Image
           </a><i class="fa fa-circle-thin read-icon"></i>
         </div>
     </li>
@@ -101,6 +108,13 @@
         <div>
           <a href="/sdk-cubic/getting-started/streaming/">
             Streaming Recognition
+          </a><i class="fa fa-circle-thin read-icon"></i>
+        </div>
+    </li>
+      <li data-nav-id="/sdk-cubic/getting-started/cubic-cli/" class="dd-item">
+        <div>
+          <a href="/sdk-cubic/getting-started/cubic-cli/">
+            Cubic Command-line Interface
           </a><i class="fa fa-circle-thin read-icon"></i>
         </div>
     </li>
@@ -309,7 +323,7 @@ audio = <span style="color:#24909d">open</span>(<span style="color:#ed9d13">&#39
 
 <div id="navigation">
 <a class="nav nav-prev" href="/sdk-cubic/getting-started/recognize/" title="Synchronous Recognition"> <i class="fa fa-chevron-left"></i><label>Synchronous Recognition</label></a>
-    <a class="nav nav-next" href="/sdk-cubic/protobuf/" title="Cubic API Reference" style="margin-right: 0px;"><label>Cubic API Reference</label><i class="fa fa-chevron-right"></i></a></div>
+    <a class="nav nav-next" href="/sdk-cubic/getting-started/cubic-cli/" title="Cubic Command-line Interface" style="margin-right: 0px;"><label>Cubic Command-line Interface</label><i class="fa fa-chevron-right"></i></a></div>
 
 </section>
 <div style="left: -1000px; overflow: scroll; position: absolute; top: -1000px; border: none; box-sizing: content-box; height: 200px; margin: 0px; padding: 0px; width: 200px;">

--- a/docs/index.html
+++ b/docs/index.html
@@ -80,7 +80,14 @@
       <li data-nav-id="/sdk-cubic/getting-started/installation/" class="dd-item">
         <div>
           <a href="/sdk-cubic/getting-started/installation/">
-            Installation
+            Installing the SDK
+          </a><i class="fa fa-circle-thin read-icon"></i>
+        </div>
+    </li>
+      <li data-nav-id="/sdk-cubic/getting-started/cubic_docker/" class="dd-item">
+        <div>
+          <a href="/sdk-cubic/getting-started/cubic_docker/">
+            Installing the cubicsvr Image
           </a><i class="fa fa-circle-thin read-icon"></i>
         </div>
     </li>
@@ -102,6 +109,13 @@
         <div>
           <a href="/sdk-cubic/getting-started/streaming/">
             Streaming Recognition
+          </a><i class="fa fa-circle-thin read-icon"></i>
+        </div>
+    </li>
+      <li data-nav-id="/sdk-cubic/getting-started/cubic-cli/" class="dd-item">
+        <div>
+          <a href="/sdk-cubic/getting-started/cubic-cli/">
+            Cubic Command-line Interface
           </a><i class="fa fa-circle-thin read-icon"></i>
         </div>
     </li>

--- a/docs/index.json
+++ b/docs/index.json
@@ -8,10 +8,17 @@
 },
 {
 	"uri": "https://cobaltspeech.github.io/sdk-cubic/getting-started/installation/",
-	"title": "Installation",
+	"title": "Installing the SDK",
 	"tags": [],
 	"description": "",
 	"content": "Instructions for installing the SDK are language specific.\nGo The Go SDK supports Go modules and requires Go 1.12 or later. To use the SDK, import this package into your application:\nimport \u0026#34;github.com/cobaltspeech/sdk-cubic/grpc/go-cubic\u0026#34; Python The Python SDK depends on Python \u0026gt;= 3.5. You may use pip to perform a system-wide install, or use virtualenv for a local install.\npip install --upgrade pip pip install \u0026#34;git+https://github.com/cobaltspeech/sdk-cubic#egg=cobalt-cubic\u0026amp;subdirectory=grpc/py-cubic\u0026#34;"
+},
+{
+	"uri": "https://cobaltspeech.github.io/sdk-cubic/getting-started/cubic_docker/",
+	"title": "Installing the cubicsvr Image",
+	"tags": [],
+	"description": "",
+	"content": "The SDK is used to call an instance of cubicsvr using gRPC. Cobalt distributes a docker image that contains the cubicsvr binary and model files.\n Contact Cobalt to get a link to the image file in AWS S3. This link will expire in two weeks, so be sure to download the file to your own server.\n Download with the AWS CLI if you have it, or with curl:\nURL=\u0026#34;the url sent by Cobalt\u0026#34; IMAGE_NAME=\u0026#34;name you want to give the file (should end with the same extension as the url, usually bz2)\u0026#34; curl $URL -L -o $IMAGE_NAME Load the docker image:\ndocker load \u0026lt; $IMAGE_NAME This will output the name of the image (e.g. cubicsvr-demo-en_us-16).\n Start the cubic service listening:\ndocker run -p 2727:2727 -p 8080:8080 --name cobalt cubicsvr-demo-en_us-16 That will start listening for grpc commands on port 2727 and http requests on 8080, and will stream the debug log to stdout. (You can replace --name cobalt with whatever name you want. That just provides a way to refer back to the currently running container.)\n Verify the service is running by calling\ncurl http://localhost:8080/api/version If you want to explore the package to see the model files etc, call the following to open the bash terminal on the previously run image. Model files are located in the /model directory.\ndocker exec -it cobalt bash  Contents of the docker image  Base docker image : debian-stretch-slim Additional dependencies (installed with yum install on centos or apt-get on ubuntu)  libgfortran3 sox   Cobalt-specific files  cubicsvr - binary for performing Automatic Speech Recognition model.config - top-level config am/nnet3_online/final.mdl - this is the acoustic model am/nnet3_online/conf/online_cmvn.conf - feature extraction parameters for the features fed into the GMM model used for i-vector statistics accumulation. am/nnet3_online/conf/splice.conf - GMM feature context when accumulating statistics for i-vector accumulation. am/nnet3_online/ivector_extractor/* - Kaldi configuration files related to ivectors\n graph/HCLG.fst - the decoding graph: the combination of the AMs transition graph, the lexicon, and the language model graph/words.txt - an integer to word mapping, needed because the output of the HCLG graph contains only integer symbol IDs graph/phones/word_boundary.int - this is needed only when confusion network output is requested, it tells the decoder which phones are at word boundaries "
 },
 {
 	"uri": "https://cobaltspeech.github.io/sdk-cubic/protobuf/",
@@ -40,6 +47,13 @@
 	"tags": [],
 	"description": "",
 	"content": "The following example shows how to transcribe an audio file using Cubic’s Streaming Recognize Request. The example uses a WAV file as input to the streaming recognition. We will query the server for available models and use the first model to transcribe the speech.\n package main import ( \u0026#34;context\u0026#34; \u0026#34;fmt\u0026#34; \u0026#34;log\u0026#34; \u0026#34;os\u0026#34; \u0026#34;github.com/cobaltspeech/sdk-cubic/grpc/go-cubic\u0026#34; \u0026#34;github.com/cobaltspeech/sdk-cubic/grpc/go-cubic/cubicpb\u0026#34; ) const serverAddr = \u0026#34;127.0.0.1:2727\u0026#34; func main() { client, err := cubic.NewClient(serverAddr) if err != nil { log.Fatal(err) } defer client.Close() modelResp, err := client.ListModels(context.Background()) if err != nil { log.Fatal(err) } // Use the first available model  model := modelResp.Models[0] f, err := os.Open(\u0026#34;test.wav\u0026#34;) if err != nil { log.Fatal(err) } defer f.Close() cfg := \u0026amp;cubicpb.RecognitionConfig{ ModelId: model.Id, } // define a callback function to handle results  resultHandler := func(resp *cubicpb.RecognitionResponse) { for _, r := range resp.Results { if !r.IsPartial { fmt.Println(r.Alternatives[0].Transcript) } } } err = client.StreamingRecognize(context.Background(), cfg, f, resultHandler) if err != nil { log.Fatal(err) } }  import cubic serverAddress = \u0026#39;127.0.0.1:2727\u0026#39; client = cubic.Client(serverAddress) # get list of available models modelResp = client.ListModels() for model in modelResp.models: print(\u0026#34;ID = {}, Name = {}\u0026#34;.format(model.id, model.name)) # use the first available model model = modelResp.models[0] cfg = cubic.RecognitionConfig( model_id = model.id ) # client.StreamingRecognize takes any binary # stream object that has a read(nBytes) method. # The method should return nBytes from the stream. # open audio file stream audio = open(\u0026#39;test.wav\u0026#39;, \u0026#39;rb\u0026#39;) # send streaming request to cubic and  # print out results as they come in for resp in client.StreamingRecognize(cfg, audio): for result in resp.results: if result.is_partial: print(\u0026#34;\\r{0}\u0026#34;.format(result.alternatives[0].transcript), end=\u0026#34;\u0026#34;) else: print(\u0026#34;\\r{0}\u0026#34;.format(result.alternatives[0].transcript), end=\u0026#34;\\n\u0026#34;)   \n"
+},
+{
+	"uri": "https://cobaltspeech.github.io/sdk-cubic/getting-started/cubic-cli/",
+	"title": "Cubic Command-line Interface",
+	"tags": [],
+	"description": "",
+	"content": "Cobalt provides a command-line interface built using our Go SDK to specify an audio file or list of files and get transcripts back from a running instance of cubicsvr. The source code is available to use as an example client.\n"
 },
 {
 	"uri": "https://cobaltspeech.github.io/sdk-cubic/protobuf/autogen-doc-cubic-proto/",

--- a/docs/index.xml
+++ b/docs/index.xml
@@ -11,12 +11,21 @@
     
     
     <item>
-      <title>Installation</title>
+      <title>Installing the SDK</title>
       <link>https://cobaltspeech.github.io/sdk-cubic/getting-started/installation/</link>
       <pubDate>Mon, 01 Jan 0001 00:00:00 +0000</pubDate>
       
       <guid>https://cobaltspeech.github.io/sdk-cubic/getting-started/installation/</guid>
       <description>&lt;p&gt;Instructions for installing the SDK are language specific.&lt;/p&gt;</description>
+    </item>
+    
+    <item>
+      <title>Installing the cubicsvr Image</title>
+      <link>https://cobaltspeech.github.io/sdk-cubic/getting-started/cubic_docker/</link>
+      <pubDate>Mon, 01 Jan 0001 00:00:00 +0000</pubDate>
+      
+      <guid>https://cobaltspeech.github.io/sdk-cubic/getting-started/cubic_docker/</guid>
+      <description>&lt;p&gt;The SDK is used to call an instance of cubicsvr using gRPC.  Cobalt distributes a docker image that contains the cubicsvr binary and model files.&lt;/p&gt;</description>
     </item>
     
     <item>
@@ -55,6 +64,15 @@ recognition.&lt;/p&gt;</description>
 Streaming Recognize Request. The example uses a WAV file as input to the
 streaming recognition. We will query the server for available models and
 use the first model to transcribe the speech.&lt;/p&gt;</description>
+    </item>
+    
+    <item>
+      <title>Cubic Command-line Interface</title>
+      <link>https://cobaltspeech.github.io/sdk-cubic/getting-started/cubic-cli/</link>
+      <pubDate>Mon, 01 Jan 0001 00:00:00 +0000</pubDate>
+      
+      <guid>https://cobaltspeech.github.io/sdk-cubic/getting-started/cubic-cli/</guid>
+      <description>Cobalt provides a command-line interface built using our Go SDK to specify an audio file or list of files and get transcripts back from a running instance of cubicsvr. The source code is available to use as an example client.</description>
     </item>
     
     <item>

--- a/docs/protobuf/autogen-doc-cubic-proto/index.html
+++ b/docs/protobuf/autogen-doc-cubic-proto/index.html
@@ -79,7 +79,14 @@
       <li data-nav-id="/sdk-cubic/getting-started/installation/" class="dd-item">
         <div>
           <a href="/sdk-cubic/getting-started/installation/">
-            Installation
+            Installing the SDK
+          </a><i class="fa fa-circle-thin read-icon"></i>
+        </div>
+    </li>
+      <li data-nav-id="/sdk-cubic/getting-started/cubic_docker/" class="dd-item">
+        <div>
+          <a href="/sdk-cubic/getting-started/cubic_docker/">
+            Installing the cubicsvr Image
           </a><i class="fa fa-circle-thin read-icon"></i>
         </div>
     </li>
@@ -101,6 +108,13 @@
         <div>
           <a href="/sdk-cubic/getting-started/streaming/">
             Streaming Recognition
+          </a><i class="fa fa-circle-thin read-icon"></i>
+        </div>
+    </li>
+      <li data-nav-id="/sdk-cubic/getting-started/cubic-cli/" class="dd-item">
+        <div>
+          <a href="/sdk-cubic/getting-started/cubic-cli/">
+            Cubic Command-line Interface
           </a><i class="fa fa-circle-thin read-icon"></i>
         </div>
     </li>

--- a/docs/protobuf/index.html
+++ b/docs/protobuf/index.html
@@ -79,7 +79,14 @@
       <li data-nav-id="/sdk-cubic/getting-started/installation/" class="dd-item">
         <div>
           <a href="/sdk-cubic/getting-started/installation/">
-            Installation
+            Installing the SDK
+          </a><i class="fa fa-circle-thin read-icon"></i>
+        </div>
+    </li>
+      <li data-nav-id="/sdk-cubic/getting-started/cubic_docker/" class="dd-item">
+        <div>
+          <a href="/sdk-cubic/getting-started/cubic_docker/">
+            Installing the cubicsvr Image
           </a><i class="fa fa-circle-thin read-icon"></i>
         </div>
     </li>
@@ -101,6 +108,13 @@
         <div>
           <a href="/sdk-cubic/getting-started/streaming/">
             Streaming Recognition
+          </a><i class="fa fa-circle-thin read-icon"></i>
+        </div>
+    </li>
+      <li data-nav-id="/sdk-cubic/getting-started/cubic-cli/" class="dd-item">
+        <div>
+          <a href="/sdk-cubic/getting-started/cubic-cli/">
+            Cubic Command-line Interface
           </a><i class="fa fa-circle-thin read-icon"></i>
         </div>
     </li>
@@ -209,7 +223,7 @@ methods that can be called.</p>
 </div>
 
 <div id="navigation">
-<a class="nav nav-prev" href="/sdk-cubic/getting-started/streaming/" title="Streaming Recognition"> <i class="fa fa-chevron-left"></i><label>Streaming Recognition</label></a>
+<a class="nav nav-prev" href="/sdk-cubic/getting-started/cubic-cli/" title="Cubic Command-line Interface"> <i class="fa fa-chevron-left"></i><label>Cubic Command-line Interface</label></a>
     <a class="nav nav-next" href="/sdk-cubic/protobuf/autogen-doc-cubic-proto/" title="Cubic Protobuf API Docs" style="margin-right: 0px;"><label>Cubic Protobuf API Docs</label><i class="fa fa-chevron-right"></i></a></div>
 
 </section>

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -11,6 +11,10 @@
   </url>
   
   <url>
+    <loc>https://cobaltspeech.github.io/sdk-cubic/getting-started/cubic_docker/</loc>
+  </url>
+  
+  <url>
     <loc>https://cobaltspeech.github.io/sdk-cubic/protobuf/</loc>
   </url>
   
@@ -24,6 +28,10 @@
   
   <url>
     <loc>https://cobaltspeech.github.io/sdk-cubic/getting-started/streaming/</loc>
+  </url>
+  
+  <url>
+    <loc>https://cobaltspeech.github.io/sdk-cubic/getting-started/cubic-cli/</loc>
   </url>
   
   <url>

--- a/docs/tags/index.html
+++ b/docs/tags/index.html
@@ -79,7 +79,14 @@
       <li data-nav-id="/sdk-cubic/getting-started/installation/" class="dd-item">
         <div>
           <a href="/sdk-cubic/getting-started/installation/">
-            Installation
+            Installing the SDK
+          </a><i class="fa fa-circle-thin read-icon"></i>
+        </div>
+    </li>
+      <li data-nav-id="/sdk-cubic/getting-started/cubic_docker/" class="dd-item">
+        <div>
+          <a href="/sdk-cubic/getting-started/cubic_docker/">
+            Installing the cubicsvr Image
           </a><i class="fa fa-circle-thin read-icon"></i>
         </div>
     </li>
@@ -101,6 +108,13 @@
         <div>
           <a href="/sdk-cubic/getting-started/streaming/">
             Streaming Recognition
+          </a><i class="fa fa-circle-thin read-icon"></i>
+        </div>
+    </li>
+      <li data-nav-id="/sdk-cubic/getting-started/cubic-cli/" class="dd-item">
+        <div>
+          <a href="/sdk-cubic/getting-started/cubic-cli/">
+            Cubic Command-line Interface
           </a><i class="fa fa-circle-thin read-icon"></i>
         </div>
     </li>


### PR DESCRIPTION
We are still pointing customers to https://github.com/cobaltspeech/client/blob/master/docs/cubic_docker.md when we send them a docker image.  I think it would be better to have that part of our nicely formatted docs and remove the (now obsolete) client repo altogether. The only other doc that's there (https://github.com/cobaltspeech/client/blob/master/docs/pulling-from-ECR.md) is really more internally focused, since we no longer intend to grant ECR access to customers.

You only need to review the changes in docs-src, not in the generated /docs folder.