### PR TITLE
csharp: fix release instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,9 @@ git checkout -b version-update-v$NEW_VERSION
 sed -i 's|grpc/go-cubic v[0-9.]*|grpc/go-cubic v'$NEW_VERSION'|g' grpc/go-cubic/cubicpb/gw/go.mod
 sed -i 's|version='\''[0-9.]*'\''|version='\'$NEW_VERSION\''|g' grpc/py-cubic/setup.py
 
+sed -i 's|<Version>[0-9.]*</Version>|<Version>'$NEW_VERSION'</Version>|g' grpc/csharp-cubic/cubic.csproj
+sed -i 's|CSHARP_RELEASE_VERSION="[0-9.]*"|CSHARP_RELEASE_VERSION="'$NEW_VERSION'"|g' grpc/Makefile
+
 git commit -m "Update version to v$NEW_VERSION"
 git push origin version-update-v$NEW_VERSION
 ```

--- a/grpc/Makefile
+++ b/grpc/Makefile
@@ -19,14 +19,14 @@ py: $(PY_OUTDIR)/cubic_pb2.py ${PY_OUTDIR}/cubic_pb2_grpc.py py-test
 ## C#
 ## https://docs.microsoft.com/en-us/nuget/quickstart/create-and-publish-a-package-using-the-dotnet-cli
 ## You need to copy the PROTOINC files over to the ~/.nuget/packages/grpc.tools/1.22.0/build/native/include directory.
-VERSION="1.2.2"
+CSHARP_RELEASE_VERSION="1.3.0"
 NUGET_API_KEY="" # Must be set to push the nuget package.
 cs:
 	cd csharp-cubic/ && dotnet build ./cubic.csproj \
-		-p:PackageVersion=${VERSION}
+		-p:PackageVersion=${CSHARP_RELEASE_VERSION}
 cs_push:
 	dotnet nuget push \
-		./csharp-cubic/bin/Debug/Cubic-SDK.${VERSION}.nupkg \
+		./csharp-cubic/bin/Debug/Cubic-SDK.${CSHARP_RELEASE_VERSION}.nupkg \
 		-k ${NUGET_API_KEY} \
 		-s https://api.nuget.org/v3/index.json
 

--- a/grpc/csharp-cubic/cubic.csproj
+++ b/grpc/csharp-cubic/cubic.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <PackageId>Cubic-SDK</PackageId>
-    <Version>1.2.1</Version>
+    <Version>1.3.0</Version>
     <VersionSuffix>$(VersionSuffix)</VersionSuffix>
     <Authors>Jacob Holloway</Authors>
     <Company>Cobalt Speech and Language, Inc.</Company>


### PR DESCRIPTION
Added instructions to the readme to update version tag in c# assets.  Also fixed
the current version to be 1.3.0.

Fixes #59 