### PR TITLE
doc: init hugo module

### DIFF
--- a/docs-src/go.mod
+++ b/docs-src/go.mod
@@ -1,0 +1,3 @@
+module github.com/cobaltspeech/sdk-cubic/docs-src
+
+go 1.13


### PR DESCRIPTION
Use `hugo mod init` to create a go.mod file so that it can be imported into other hugo projects.  
The idea is that we'll have one top-level documentation site that imports the other repos.