### PR TITLE
CU-865bp8744 py: update grpc deps

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,38 +1,42 @@
 #!groovy
-// Copyright (2020) Cobalt Speech and Language Inc.
+ // Copyright (2020) Cobalt Speech and Language Inc.
 
 // Keep only 10 builds on Jenkins
 properties([
-    buildDiscarder(logRotator(
-        artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '10'))
+  buildDiscarder(logRotator(
+    artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '10'))
 ])
 
 if (env.CHANGE_ID) {
-    // Building a pull request
-    node {
-	try {
-	    timeout(time: 30, unit: 'MINUTES'){
-		checkout scm
-		def sdkGenImage = docker.build("sdk-generator", "./ci")
-		sdkGenImage.inside('-u root') {
-		    stage("validate") {
-			try {
-			    commit.setBuildStatus("validate-built-artifacts", "PENDING", "Validating generated artifacts.")
-			    sh 'make'
-			    sh "git diff --exit-code"
-			} finally {
-			    // Allow Jenkins to cleanup workspace
-			    sh "chown -R 1000:1000 ."
-			}
-		    }
-		}
-		commit.setBuildStatus("validate-built-artifacts", "SUCCESS", "Successfully validated.")
-	    }
-	} catch(err) {
-	    commit.setBuildStatus("validate-built-artifacts", "ERROR", "Validation failed.")
-	    throw err
-	} finally {
-	    deleteDir()
-	}
+  // Building a pull request
+  node {
+    try {
+    timeout(time: 30, unit: 'MINUTES') {
+      checkout scm
+      sh "git config --global --add safe.directory '*'"
+
+      stage("validate-built-artifacts") {
+        commit.setBuildStatus("validate-built-artifacts", "PENDING", "Validating generated artifacts.")
+
+        def sdkGenImage = docker.build("sdk-generator", "./ci")
+          sdkGenImage.inside('-u root') {
+            try {
+              sh "git config --global --add safe.directory '*'"
+              sh "make"
+              sh "git diff --exit-code"
+            } finally {
+              // Allow Jenkins to cleanup workspace
+              sh "chown -R 1000:1000 ."
+            }
+          }
+        }
+        commit.setBuildStatus("validate-built-artifacts", "SUCCESS", "Successfully validated.")
+      }
+    } catch (err) {
+      commit.setBuildStatus("validate-built-artifacts", "ERROR", "Validation failed.")
+      throw err
+    } finally {
+      deleteDir()
     }
+  }
 }

--- a/Makefile
+++ b/Makefile
@@ -14,10 +14,10 @@ PROTOC_GEN_GRPC_GATEWAY_VERSION := 1.14.4
 PY_GRPC_VERSION := 1.28.1
 PY_GRPCIO_VERSION := 1.31.0 # 1.32.0 uses boring SSL and some tls tests fail -- https://github.com/grpc/grpc/issues/24252
 PY_GOOGLEAPIS_VERSION := 1.51.0
-
+PY_PROTOBUF_VERSION := 3.20
 SWIFT_GRPC_VERSION := 1.6.1
 
-SHELL := /bin/bash
+SHELL := /usr/bin/env bash
 
 TOP := $(shell pwd)
 
@@ -62,7 +62,7 @@ ${DEPSGO}/bin/protoc-gen-grpc-gateway:
 deps-py: ${DEPSVENV}/.done
 ${DEPSVENV}/.done:
 	virtualenv -p python3 ${DEPSVENV}
-	source ${DEPSVENV}/bin/activate && pip install grpcio==$(PY_GRPCIO_VERSION) grpcio-tools==$(PY_GRPC_VERSION) googleapis-common-protos==$(PY_GOOGLEAPIS_VERSION) && deactivate
+	source ${DEPSVENV}/bin/activate && pip install grpcio==$(PY_GRPCIO_VERSION) grpcio-tools==$(PY_GRPC_VERSION) googleapis-common-protos==$(PY_GOOGLEAPIS_VERSION) protobuf==$(PY_PROTOBUF_VERSION) && deactivate
 	touch $@
 
 deps-swift: ${DEPSSWIFT}/.done

--- a/docs-src/content/using-cubic-sdk/installation.md
+++ b/docs-src/content/using-cubic-sdk/installation.md
@@ -63,7 +63,7 @@ The Cubic SDK is published to the jitpack repository.  To build using Maven, add
     <dependency>
         <groupId>com.github.cobaltspeech</groupId>
         <artifactId>sdk-cubic</artifactId>
-        <version>v1.6.4-java</version>
+        <version>v1.6.5-java</version>
     </dependency>
 </dependencies>
 ```
@@ -83,7 +83,7 @@ allprojects {
 Then add sdk-cubic as a dependency:
 ``` gradle
 dependencies {
-    implementation 'com.github.cobaltspeech:sdk-cubic:v1.6.4'
+    implementation 'com.github.cobaltspeech:sdk-cubic:v1.6.5'
 }
 ```
 #### From Source Code
@@ -98,6 +98,6 @@ Once you have your Swift package set up, adding swift-cubic as a dependency is a
 
 ```swift
 dependencies: [
-    .package(url: "git@github.com:cobaltspeech/sdk-cubic.git", .upToNextMajor(from: "1.6.4"))
+    .package(url: "git@github.com:cobaltspeech/sdk-cubic.git", .upToNextMajor(from: "1.6.5"))
 ]
 ```

--- a/grpc/Makefile
+++ b/grpc/Makefile
@@ -62,7 +62,7 @@ py-test:
 ## C#
 ## https://docs.microsoft.com/en-us/nuget/quickstart/create-and-publish-a-package-using-the-dotnet-cli
 ## You need to copy the PROTOINC files over to the ~/.nuget/packages/grpc.tools/1.22.0/build/native/include directory.
-CSHARP_RELEASE_VERSION="1.6.4"
+CSHARP_RELEASE_VERSION="1.6.5"
 NUGET_API_KEY="" # Must be set to push the nuget package.
 cs:
 	cd csharp-cubic/ && dotnet build ./cubic.csproj \

--- a/grpc/csharp-cubic/cubic.csproj
+++ b/grpc/csharp-cubic/cubic.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <PackageId>Cubic-SDK</PackageId>
-    <Version>1.6.4</Version>
+    <Version>1.6.5</Version>
     <VersionSuffix>$(VersionSuffix)</VersionSuffix>
     <Authors>Jacob Holloway</Authors>
     <Company>Cobalt Speech and Language, Inc.</Company>

--- a/grpc/go-cubic/cubicpb/gw/go.mod
+++ b/grpc/go-cubic/cubicpb/gw/go.mod
@@ -3,7 +3,7 @@ module github.com/cobaltspeech/sdk-cubic/grpc/go-cubic/cubicpb/gw
 go 1.12
 
 require (
-	github.com/cobaltspeech/sdk-cubic/grpc/go-cubic v1.6.4
+	github.com/cobaltspeech/sdk-cubic/grpc/go-cubic v1.6.5
 	github.com/golang/protobuf v1.5.2
 	github.com/grpc-ecosystem/grpc-gateway v1.16.0
 	google.golang.org/grpc v1.36.1

--- a/grpc/py-cubic/setup.py
+++ b/grpc/py-cubic/setup.py
@@ -4,14 +4,15 @@ from setuptools import setup
 setup(
     name='cobalt-cubic',
     python_requires='>=3.5.0',
-    version='1.6.4',
+    version='1.6.5',
     description='This client library is designed to support the Cobalt API for speech recognition with Cubic',
     author='Cobalt Speech and Language Inc.',
     maintainer_email='tech@cobaltspeech.com',
     url='https://cobaltspeech.github.io/sdk-cubic',
     packages=["cubic"],
     install_requires=[
-        'googleapis-common-protos==1.52.0',
-        'grpcio-tools==1.35.0'
+        'googleapis-common-protos==1.56.4',
+        'grpcio-tools==1.48.2',
+        'protobuf==3.20.0'
     ]
 )

--- a/grpc/swift-cubic/Cubic.swift
+++ b/grpc/swift-cubic/Cubic.swift
@@ -12,4 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-public let CubicVersion = "1.6.4"
+public let CubicVersion = "1.6.5"

--- a/grpc/swift-cubic/cubic.pb.swift
+++ b/grpc/swift-cubic/cubic.pb.swift
@@ -857,6 +857,34 @@ public struct Cobaltspeech_Cubic_ConfusionNetworkArc {
   public init() {}
 }
 
+#if swift(>=5.5) && canImport(_Concurrency)
+extension Cobaltspeech_Cubic_ListModelsRequest: @unchecked Sendable {}
+extension Cobaltspeech_Cubic_RecognizeRequest: @unchecked Sendable {}
+extension Cobaltspeech_Cubic_StreamingRecognizeRequest: @unchecked Sendable {}
+extension Cobaltspeech_Cubic_StreamingRecognizeRequest.OneOf_Request: @unchecked Sendable {}
+extension Cobaltspeech_Cubic_CompileContextRequest: @unchecked Sendable {}
+extension Cobaltspeech_Cubic_VersionResponse: @unchecked Sendable {}
+extension Cobaltspeech_Cubic_ListModelsResponse: @unchecked Sendable {}
+extension Cobaltspeech_Cubic_RecognitionResponse: @unchecked Sendable {}
+extension Cobaltspeech_Cubic_CompileContextResponse: @unchecked Sendable {}
+extension Cobaltspeech_Cubic_RecognitionConfig: @unchecked Sendable {}
+extension Cobaltspeech_Cubic_RecognitionConfig.Encoding: @unchecked Sendable {}
+extension Cobaltspeech_Cubic_RecognitionMetadata: @unchecked Sendable {}
+extension Cobaltspeech_Cubic_RecognitionContext: @unchecked Sendable {}
+extension Cobaltspeech_Cubic_CompiledContext: @unchecked Sendable {}
+extension Cobaltspeech_Cubic_ContextPhrase: @unchecked Sendable {}
+extension Cobaltspeech_Cubic_RecognitionAudio: @unchecked Sendable {}
+extension Cobaltspeech_Cubic_Model: @unchecked Sendable {}
+extension Cobaltspeech_Cubic_ModelAttributes: @unchecked Sendable {}
+extension Cobaltspeech_Cubic_ContextInfo: @unchecked Sendable {}
+extension Cobaltspeech_Cubic_RecognitionResult: @unchecked Sendable {}
+extension Cobaltspeech_Cubic_RecognitionAlternative: @unchecked Sendable {}
+extension Cobaltspeech_Cubic_WordInfo: @unchecked Sendable {}
+extension Cobaltspeech_Cubic_RecognitionConfusionNetwork: @unchecked Sendable {}
+extension Cobaltspeech_Cubic_ConfusionNetworkLink: @unchecked Sendable {}
+extension Cobaltspeech_Cubic_ConfusionNetworkArc: @unchecked Sendable {}
+#endif  // swift(>=5.5) && canImport(_Concurrency)
+
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
 fileprivate let _protobuf_package = "cobaltspeech.cubic"

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.github.cobaltspeech.sdk</groupId>
   <artifactId>sdk-cubic</artifactId>
   <packaging>jar</packaging>
-  <version>v1.6.4</version>
+  <version>v1.6.5</version>
   <name>java-cobaltspeech-cubic-sdk</name>
   <url>https://docs.cobaltspeech.com</url>
   <properties>


### PR DESCRIPTION
  - Updated googleapis-common-protos to v1.56.4, grpcio-tools to v1.48.2 which is the latest version that supports protobuf v3.20.0; using a later version will require regenerating code from the proto file with a newer protoc compiler which will affect multiple languages. Currently sticking with v3.20.0 for now.

  - Bumped SDK version to v1.6.5.